### PR TITLE
Add FastAPI backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,4 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+database.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY ./app ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# diet-clinic-app
+# Diet Clinic Backend
+
+This repository contains a minimal FastAPI backend for a diet clinic management application.
+It uses SQLite for persistence and JWT for authentication.
+
+## Features
+- User roles: admin, dietitian, patient
+- Models: User, Appointment, DietPlan, FoodLog
+- JWT login system
+- Docker support
+
+## Development
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the application:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+## Docker
+Build and run the image:
+```bash
+docker build -t diet-clinic .
+docker run -p 8000:8000 diet-clinic
+```

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,66 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+from .database import SessionLocal
+
+# In a production setting, these should be environment variables
+SECRET_KEY = "secret-key"  # Replace with a secure key
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+def verify_password(plain_password, hashed_password):
+    return pwd_context.verify(plain_password, hashed_password)
+
+def get_password_hash(password):
+    return pwd_context.hash(password)
+
+def authenticate_user(db: Session, username: str, password: str) -> Optional[models.User]:
+    user = db.query(models.User).filter(models.User.username == username).first()
+    if not user:
+        return None
+    if not verify_password(password, user.hashed_password):
+        return None
+    return user
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=15))
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+def get_current_user(db: Session = Depends(get_db), token: str = Depends(oauth2_scheme)):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        username: str = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    user = db.query(models.User).filter(models.User.username == username).first()
+    if user is None:
+        raise credentials_exception
+    return user

--- a/app/crud.py
+++ b/app/crud.py
@@ -1,0 +1,58 @@
+from sqlalchemy.orm import Session
+from . import models, schemas
+from .auth import get_password_hash
+
+
+def create_user(db: Session, user: schemas.UserCreate) -> models.User:
+    db_user = models.User(
+        username=user.username,
+        email=user.email,
+        full_name=user.full_name,
+        hashed_password=get_password_hash(user.password),
+        role=user.role.value if hasattr(user.role, "value") else user.role,
+    )
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+def get_user_by_username(db: Session, username: str):
+    return db.query(models.User).filter(models.User.username == username).first()
+
+
+def create_appointment(db: Session, appointment: schemas.AppointmentCreate) -> models.Appointment:
+    db_obj = models.Appointment(
+        date=appointment.date,
+        description=appointment.description,
+        patient_id=appointment.patient_id,
+        dietitian_id=appointment.dietitian_id,
+    )
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def create_diet_plan(db: Session, plan: schemas.DietPlanCreate) -> models.DietPlan:
+    db_obj = models.DietPlan(
+        details=plan.details,
+        patient_id=plan.patient_id,
+        dietitian_id=plan.dietitian_id,
+    )
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def create_food_log(db: Session, log: schemas.FoodLogCreate) -> models.FoodLog:
+    db_obj = models.FoodLog(
+        date=log.date,
+        meal_details=log.meal_details,
+        patient_id=log.patient_id,
+    )
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,11 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./database.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,37 @@
+from datetime import timedelta
+
+from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
+
+from . import auth, crud, models, schemas
+from .database import Base, engine
+
+# Create tables
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="Diet Clinic API")
+
+@app.post("/register", response_model=schemas.User)
+def register(user: schemas.UserCreate, db: Session = Depends(auth.get_db)):
+    db_user = crud.get_user_by_username(db, username=user.username)
+    if db_user:
+        raise HTTPException(status_code=400, detail="Username already registered")
+    return crud.create_user(db=db, user=user)
+
+@app.post("/token", response_model=schemas.Token)
+def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(auth.get_db)):
+    user = auth.authenticate_user(db, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED,
+                            detail="Incorrect username or password",
+                            headers={"WWW-Authenticate": "Bearer"})
+    access_token_expires = timedelta(minutes=auth.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = auth.create_access_token(
+        data={"sub": user.username}, expires_delta=access_token_expires
+    )
+    return {"access_token": access_token, "token_type": "bearer"}
+
+@app.get("/users/me", response_model=schemas.User)
+def read_users_me(current_user: models.User = Depends(auth.get_current_user)):
+    return current_user

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,57 @@
+from enum import Enum
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Text
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+class Role(str, Enum):
+    admin = "admin"
+    dietitian = "dietitian"
+    patient = "patient"
+
+class User(Base):
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True, nullable=False)
+    full_name = Column(String, nullable=True)
+    email = Column(String, unique=True, index=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    role = Column(String, default=Role.patient.value)
+
+    appointments_as_patient = relationship(
+        "Appointment", back_populates="patient", foreign_keys="Appointment.patient_id"
+    )
+    appointments_as_dietitian = relationship(
+        "Appointment", back_populates="dietitian", foreign_keys="Appointment.dietitian_id"
+    )
+    diet_plans = relationship("DietPlan", back_populates="patient")
+    food_logs = relationship("FoodLog", back_populates="patient")
+
+class Appointment(Base):
+    __tablename__ = "appointments"
+    id = Column(Integer, primary_key=True, index=True)
+    date = Column(DateTime, nullable=False)
+    description = Column(Text, nullable=True)
+    patient_id = Column(Integer, ForeignKey("users.id"))
+    dietitian_id = Column(Integer, ForeignKey("users.id"))
+
+    patient = relationship("User", back_populates="appointments_as_patient", foreign_keys=[patient_id])
+    dietitian = relationship("User", back_populates="appointments_as_dietitian", foreign_keys=[dietitian_id])
+
+class DietPlan(Base):
+    __tablename__ = "diet_plans"
+    id = Column(Integer, primary_key=True, index=True)
+    details = Column(Text, nullable=False)
+    patient_id = Column(Integer, ForeignKey("users.id"))
+    dietitian_id = Column(Integer, ForeignKey("users.id"))
+
+    patient = relationship("User", back_populates="diet_plans", foreign_keys=[patient_id])
+
+class FoodLog(Base):
+    __tablename__ = "food_logs"
+    id = Column(Integer, primary_key=True, index=True)
+    date = Column(DateTime, nullable=False)
+    meal_details = Column(Text, nullable=False)
+    patient_id = Column(Integer, ForeignKey("users.id"))
+
+    patient = relationship("User", back_populates="food_logs")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,74 @@
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, EmailStr
+
+class Role(str, Enum):
+    admin = "admin"
+    dietitian = "dietitian"
+    patient = "patient"
+
+class UserBase(BaseModel):
+    username: str
+    email: EmailStr
+    full_name: Optional[str] = None
+    role: Role = Role.patient
+
+class UserCreate(UserBase):
+    password: str
+
+class User(UserBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+
+class AppointmentBase(BaseModel):
+    date: datetime
+    description: Optional[str] = None
+
+class AppointmentCreate(AppointmentBase):
+    patient_id: int
+    dietitian_id: int
+
+class Appointment(AppointmentBase):
+    id: int
+    patient_id: int
+    dietitian_id: int
+
+    class Config:
+        orm_mode = True
+
+class DietPlanBase(BaseModel):
+    details: str
+
+class DietPlanCreate(DietPlanBase):
+    patient_id: int
+    dietitian_id: int
+
+class DietPlan(DietPlanBase):
+    id: int
+    patient_id: int
+    dietitian_id: int
+
+    class Config:
+        orm_mode = True
+
+class FoodLogBase(BaseModel):
+    date: datetime
+    meal_details: str
+
+class FoodLogCreate(FoodLogBase):
+    patient_id: int
+
+class FoodLog(FoodLogBase):
+    id: int
+    patient_id: int
+
+    class Config:
+        orm_mode = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn[standard]
+SQLAlchemy
+python-jose[cryptography]
+passlib[bcrypt]


### PR DESCRIPTION
## Summary
- implement FastAPI backend with SQLite
- add authentication with JWT and role-based models
- provide Dockerfile and requirements
- update README

## Testing
- `python -m py_compile $(find app -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c0d506b288324a5899148ac548781