### PR TITLE
Add Chakra dashboard layout

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,11 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-router-dom": "^6.21.1"
+    "react-router-dom": "^6.21.1",
+    "@chakra-ui/react": "^2.7.2",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "framer-motion": "^10.16.5"
   },
   "devDependencies": {
     "@types/react": "^18.2.24",

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
+import { ChakraProvider } from '@chakra-ui/react';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <ChakraProvider>
+      <App />
+    </ChakraProvider>
   </React.StrictMode>
 );

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,13 +1,33 @@
+import {
+  Box,
+  Button,
+  Heading,
+  SimpleGrid,
+  Stat,
+  StatLabel,
+} from '@chakra-ui/react';
+import { Link as RouterLink } from 'react-router-dom';
+
 type Props = {
   user: string;
 };
 
 const Dashboard = ({ user }: Props) => {
   return (
-    <div className="dashboard">
-      <h1>Patient Dashboard</h1>
-      <p>Welcome, {user}!</p>
-    </div>
+    <Box p={4}>
+      <Heading size="lg" mb={6}>{`Hi, ${user}!`}</Heading>
+      <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4} mb={6}>
+        <Stat p={4} borderWidth="1px" borderRadius="md">
+          <StatLabel>Upcoming Appointments</StatLabel>
+        </Stat>
+        <Stat p={4} borderWidth="1px" borderRadius="md">
+          <StatLabel>Active Diet Plan</StatLabel>
+        </Stat>
+      </SimpleGrid>
+      <Button as={RouterLink} to="/book-appointment" colorScheme="teal">
+        Book new appointment
+      </Button>
+    </Box>
   );
 };
 


### PR DESCRIPTION
## Summary
- add Chakra UI packages
- wrap the app with `ChakraProvider`
- redesign `Dashboard` page using Chakra components

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c1a429c6883248c5df261abeca221