### PR TITLE
Add Laravel skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ make dev-up
 This command builds the Docker containers and starts the backend, frontend and database.
 
 The app will be available at `http://localhost:3000`.
+
+## Laravel Application
+
+A Laravel 11 skeleton is available in the `laravel/` directory. It demonstrates a basic structure for role-based dashboards for Admin, Doctor, and Patient along with migrations and routes.

--- a/laravel/.env.example
+++ b/laravel/.env.example
@@ -1,0 +1,15 @@
+APP_NAME=Laravel
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost
+
+LOG_CHANNEL=stack
+
+DB_CONNECTION=mysql
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_DATABASE=diet_clinic
+DB_USERNAME=root
+DB_PASSWORD=
+

--- a/laravel/app/Http/Controllers/AdminController.php
+++ b/laravel/app/Http/Controllers/AdminController.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Doctor;
+use App\Models\Patient;
+use App\Models\User;
+
+class AdminController extends Controller
+{
+    public function dashboard()
+    {
+        return view('admin.dashboard');
+    }
+
+    // Additional CRUD methods would go here
+}

--- a/laravel/app/Http/Controllers/AppointmentController.php
+++ b/laravel/app/Http/Controllers/AppointmentController.php
@@ -1,0 +1,18 @@
+<?php
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Appointment;
+
+class AppointmentController extends Controller
+{
+    public function store(Request $request)
+    {
+        // Logic to store appointment
+    }
+
+    public function update(Request $request, Appointment $appointment)
+    {
+        // Logic to update appointment
+    }
+}

--- a/laravel/app/Http/Controllers/Controller.php
+++ b/laravel/app/Http/Controllers/Controller.php
@@ -1,0 +1,9 @@
+<?php
+namespace App\Http\Controllers;
+
+use Illuminate\Routing\Controller as BaseController;
+
+class Controller extends BaseController
+{
+    // Common functionality for controllers
+}

--- a/laravel/app/Http/Controllers/DietPlanController.php
+++ b/laravel/app/Http/Controllers/DietPlanController.php
@@ -1,0 +1,18 @@
+<?php
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\DietPlan;
+
+class DietPlanController extends Controller
+{
+    public function store(Request $request)
+    {
+        // Logic to store diet plan
+    }
+
+    public function show(DietPlan $dietPlan)
+    {
+        return view('dietplan.show', compact('dietPlan'));
+    }
+}

--- a/laravel/app/Http/Controllers/DoctorController.php
+++ b/laravel/app/Http/Controllers/DoctorController.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Doctor;
+use App\Models\Patient;
+use App\Models\Appointment;
+
+class DoctorController extends Controller
+{
+    public function dashboard()
+    {
+        return view('doctor.dashboard');
+    }
+
+    // Methods for managing appointments and diet plans
+}

--- a/laravel/app/Http/Controllers/PatientController.php
+++ b/laravel/app/Http/Controllers/PatientController.php
@@ -1,0 +1,17 @@
+<?php
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Patient;
+use App\Models\Appointment;
+use App\Models\DietPlan;
+
+class PatientController extends Controller
+{
+    public function dashboard()
+    {
+        return view('patient.dashboard');
+    }
+
+    // Methods for booking appointments and viewing plans
+}

--- a/laravel/app/Models/Appointment.php
+++ b/laravel/app/Models/Appointment.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Appointment extends Model
+{
+    protected $fillable = [
+        'doctor_id', 'patient_id', 'scheduled_at', 'notes', 'status'
+    ];
+
+    public function doctor()
+    {
+        return $this->belongsTo(Doctor::class);
+    }
+
+    public function patient()
+    {
+        return $this->belongsTo(Patient::class);
+    }
+}

--- a/laravel/app/Models/DietPlan.php
+++ b/laravel/app/Models/DietPlan.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class DietPlan extends Model
+{
+    protected $fillable = [
+        'patient_id', 'doctor_id', 'description'
+    ];
+
+    public function patient()
+    {
+        return $this->belongsTo(Patient::class);
+    }
+
+    public function doctor()
+    {
+        return $this->belongsTo(Doctor::class);
+    }
+}

--- a/laravel/app/Models/Doctor.php
+++ b/laravel/app/Models/Doctor.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Doctor extends Model
+{
+    protected $fillable = [
+        'user_id', 'specialty'
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function patients()
+    {
+        return $this->hasMany(Patient::class);
+    }
+}

--- a/laravel/app/Models/Patient.php
+++ b/laravel/app/Models/Patient.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Patient extends Model
+{
+    protected $fillable = [
+        'user_id', 'doctor_id', 'dob', 'notes'
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function doctor()
+    {
+        return $this->belongsTo(Doctor::class);
+    }
+}

--- a/laravel/app/Models/User.php
+++ b/laravel/app/Models/User.php
@@ -1,0 +1,18 @@
+<?php
+namespace App\Models;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+class User extends Authenticatable
+{
+    use Notifiable;
+
+    protected $fillable = [
+        'name', 'email', 'password', 'role'
+    ];
+
+    protected $hidden = [
+        'password', 'remember_token'
+    ];
+}

--- a/laravel/composer.json
+++ b/laravel/composer.json
@@ -1,0 +1,13 @@
+{
+    "name": "dietclinic/laravel-app",
+    "type": "project",
+    "require": {
+        "php": ">=8.2",
+        "laravel/framework": "^11.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    }
+}

--- a/laravel/database/migrations/2024_01_01_000000_create_users_table.php
+++ b/laravel/database/migrations/2024_01_01_000000_create_users_table.php
@@ -1,0 +1,25 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->string('role')->default('patient');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};

--- a/laravel/database/migrations/2024_01_01_010000_create_doctors_table.php
+++ b/laravel/database/migrations/2024_01_01_010000_create_doctors_table.php
@@ -1,0 +1,22 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('doctors', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users');
+            $table->string('specialty')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('doctors');
+    }
+};

--- a/laravel/database/migrations/2024_01_01_020000_create_patients_table.php
+++ b/laravel/database/migrations/2024_01_01_020000_create_patients_table.php
@@ -1,0 +1,24 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('patients', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users');
+            $table->foreignId('doctor_id')->nullable()->constrained('doctors');
+            $table->date('dob')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('patients');
+    }
+};

--- a/laravel/database/migrations/2024_01_01_030000_create_appointments_table.php
+++ b/laravel/database/migrations/2024_01_01_030000_create_appointments_table.php
@@ -1,0 +1,25 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('appointments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('doctor_id')->constrained('doctors');
+            $table->foreignId('patient_id')->constrained('patients');
+            $table->timestamp('scheduled_at');
+            $table->string('status')->default('pending');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('appointments');
+    }
+};

--- a/laravel/database/migrations/2024_01_01_040000_create_diet_plans_table.php
+++ b/laravel/database/migrations/2024_01_01_040000_create_diet_plans_table.php
@@ -1,0 +1,23 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('diet_plans', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('patient_id')->constrained('patients');
+            $table->foreignId('doctor_id')->constrained('doctors');
+            $table->text('description');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('diet_plans');
+    }
+};

--- a/laravel/lang/ar/messages.php
+++ b/laravel/lang/ar/messages.php
@@ -1,0 +1,5 @@
+<?php
+return [
+    'welcome' => 'مرحبا',
+    'dashboard' => 'لوحة التحكم',
+];

--- a/laravel/lang/en/messages.php
+++ b/laravel/lang/en/messages.php
@@ -1,0 +1,5 @@
+<?php
+return [
+    'welcome' => 'Welcome',
+    'dashboard' => 'Dashboard',
+];

--- a/laravel/resources/views/admin/dashboard.blade.php
+++ b/laravel/resources/views/admin/dashboard.blade.php
@@ -1,0 +1,2 @@
+<h1>Admin Dashboard</h1>
+<p>Manage doctors and patients.</p>

--- a/laravel/resources/views/dietplan/show.blade.php
+++ b/laravel/resources/views/dietplan/show.blade.php
@@ -1,0 +1,2 @@
+<h1>Diet Plan</h1>
+<p>{{ \$dietPlan->description }}</p>

--- a/laravel/resources/views/doctor/dashboard.blade.php
+++ b/laravel/resources/views/doctor/dashboard.blade.php
@@ -1,0 +1,2 @@
+<h1>Doctor Dashboard</h1>
+<p>View your patients and appointments.</p>

--- a/laravel/resources/views/patient/dashboard.blade.php
+++ b/laravel/resources/views/patient/dashboard.blade.php
@@ -1,0 +1,2 @@
+<h1>Patient Dashboard</h1>
+<p>Book appointments and view diet plans.</p>

--- a/laravel/resources/views/welcome.blade.php
+++ b/laravel/resources/views/welcome.blade.php
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Diet Clinic</title>
+</head>
+<body>
+    <h1>Welcome to Diet Clinic</h1>
+    <a href="/login">Login</a>
+</body>
+</html>

--- a/laravel/routes/auth.php
+++ b/laravel/routes/auth.php
@@ -1,0 +1,2 @@
+<?php
+// Authentication routes placeholder

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -1,0 +1,22 @@
+<?php
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AdminController;
+use App\Http\Controllers\DoctorController;
+use App\Http\Controllers\PatientController;
+use App\Http\Controllers\AppointmentController;
+use App\Http\Controllers\DietPlanController;
+
+Route::get('/', function () {
+    return view('welcome');
+});
+
+Route::middleware(['auth'])->group(function () {
+    Route::get('/admin', [AdminController::class, 'dashboard'])->middleware('role:admin');
+    Route::get('/doctor', [DoctorController::class, 'dashboard'])->middleware('role:doctor');
+    Route::get('/patient', [PatientController::class, 'dashboard'])->middleware('role:patient');
+
+    Route::resource('appointments', AppointmentController::class)->except(['create', 'edit']);
+    Route::resource('diet-plans', DietPlanController::class)->only(['store', 'show']);
+});
+
+require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- create Laravel 11 skeleton under `laravel/`
- add models, controllers, migrations, routes and views
- provide simple localization example
- document new Laravel directory in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ffd48f0883248865a37e0acda9a7